### PR TITLE
Update AutoKey.py

### DIFF
--- a/AutoKey.py
+++ b/AutoKey.py
@@ -393,7 +393,7 @@ def main(argv=None):
 
     DEVNULL = open(os.devnull, 'w')
 
-    subprocess.check_call(["inkscape", "-E", os.path.join(BRAND_DIR, "branding.eps"), os.path.join(BRAND_DIR, "branding.svg"),])
+    subprocess.check_call(["inkscape", "--export-filename", os.path.join(BRAND_DIR, "branding.eps"), os.path.join(BRAND_DIR, "branding.svg"),])
     subprocess.check_call(["pstoedit", "-nb", "-dt", "-f", "dxf:-polyaslines", os.path.join(BRAND_DIR, "branding.eps"), os.path.join(BRAND_DIR, "branding.dxf")], stderr=DEVNULL)
 
     # Read base settings
@@ -456,9 +456,9 @@ def main(argv=None):
             f.write("include <includes/default-keycombcuts.scad>;")
             f.write("\n")
 
-    subprocess.check_call(["inkscape", "-E", os.path.join(BASE_DIR, "profile.eps"), opts.profile])
+    subprocess.check_call(["inkscape", "--export-filename", os.path.join(BASE_DIR, "profile.eps"), opts.profile])
     subprocess.check_call(["pstoedit", "-nb", "-dt", "-f", "dxf:-polyaslines", os.path.join(BASE_DIR, "profile.eps"), os.path.join(BASE_DIR, "profile.dxf")], stderr=DEVNULL)
-    subprocess.check_call(["/usr/bin/openscad", os.path.join(BASE_DIR, "key.scad") ])
+    subprocess.check_call(["openscad", os.path.join(BASE_DIR, "key.scad") ])
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
- Changed inkscape args -E to --export-filename as the former does not exist (any more?)
- Replaced absolute-linux openscad path with just the executable